### PR TITLE
Performance: use == instead of = for faster search

### DIFF
--- a/06_vm_stable.md
+++ b/06_vm_stable.md
@@ -106,7 +106,7 @@ echo
 
 echo Test 1: Find some users
 $CURL $H_TENANT $H_TOKEN \
-  $OKAPIURL/users?query=personal.lastName=ab*+sortBy+username
+  $OKAPIURL/users?query=personal.lastName==ab*+sortBy+username
 echo
 
 echo Finished.


### PR DESCRIPTION
Using the right truncation match with == is fast. The substring match with
= requires a word boundary regexp match that contains left truncation and
is slow on big tables.